### PR TITLE
Add web-based attendance prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,30 +35,34 @@
 
 3. **Chạy dự án**:
    ```bash
-   python main.py
+   uvicorn api.identify:app --reload
    ```
 
 ## Hướng dẫn sử dụng
 
 1. Cài đặt hệ thống và đảm bảo kết nối camera hoạt động.
-2. Chạy tập tin chính `main.py` để khởi động chương trình.
-3. Thực hiện các bước sau trong giao diện:
-   - Đăng ký khuôn mặt mới.
-   - Tiến hành điểm danh bằng cách đối chiếu khuôn mặt.
-   - Kiểm tra và xuất báo cáo điểm danh.
+2. Chạy server FastAPI bằng lệnh ở trên.
+3. Mở `frontend/index.html` trên trình duyệt để chụp ảnh và gửi embedding.
+4. Hệ thống sẽ trả về kết quả nhận diện và ghi nhận chấm công.
 
 ## Cấu trúc thư mục
 
 ```plaintext
 face-atendance/
 │
-├── main.py              # Tệp khởi động chính
-├── models/              # Lưu trữ các mô hình nhận diện khuôn mặt
-├── data/                # Dữ liệu người dùng và hình ảnh
-├── utils/               # Các công cụ hỗ trợ
-├── requirements.txt     # Danh sách thư viện cần thiết
+├── api/                 # FastAPI serverless functions
+│   └── identify.py      # API nhận diện khuôn mặt
+├── frontend/            # Giao diện web đơn giản
+│   └── index.html
+├── requirements.txt     # Thư viện Python cần thiết
 └── README.md            # Tệp hướng dẫn (bạn đang đọc)
 ```
+
+## Deploy lên Vercel
+1. Tạo GitHub repository và push mã nguồn này.
+2. Vào dashboard Vercel, chọn **New Project** và kết nối tới repo.
+3. Thiết lập thư mục root ở repo và đảm bảo Vercel nhận diện thư mục `api/` làm Serverless Functions.
+4. Mỗi lần push lên GitHub, Vercel sẽ tự động build và cung cấp URL cho hệ thống.
 
 ## Đóng góp
 Chúng tôi khuyến khích các đóng góp từ cộng đồng! Nếu bạn muốn đóng góp, hãy thực hiện các bước sau:
@@ -79,6 +83,3 @@ Nếu bạn có bất kỳ câu hỏi hoặc đề xuất nào, vui lòng liên 
 ---
 
 Cảm ơn bạn đã sử dụng **Face Attendance System**!
-```
-
-Hãy cho tôi biết nếu bạn muốn thêm thông tin cụ thể hoặc thay đổi một phần nào đó của README này!

--- a/api/identify.py
+++ b/api/identify.py
@@ -1,0 +1,40 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import numpy as np
+import onnxruntime as ort
+import os
+
+app = FastAPI()
+
+MODEL_PATH = os.getenv("MODEL_PATH", "model.onnx")
+EMBEDDINGS_PATH = os.getenv("EMBEDDINGS_PATH", "embeddings.npy")
+IDS_PATH = os.getenv("IDS_PATH", "user_ids.npy")
+
+# Load model and embeddings at startup
+try:
+    session = ort.InferenceSession(MODEL_PATH, providers=["CPUExecutionProvider"])
+    known_embeddings = np.load(EMBEDDINGS_PATH)
+    user_ids = np.load(IDS_PATH)
+except Exception as e:
+    session = None
+    known_embeddings = None
+    user_ids = None
+
+class Embedding(BaseModel):
+    vector: list[float]
+
+@app.post("/identify")
+def identify(data: Embedding):
+    if session is None or known_embeddings is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    emb = np.array(data.vector, dtype=np.float32)
+    if emb.shape[0] != known_embeddings.shape[1]:
+        raise HTTPException(status_code=400, detail="Invalid embedding size")
+
+    norms = np.linalg.norm(known_embeddings, axis=1) * np.linalg.norm(emb)
+    sims = known_embeddings @ emb / norms
+    idx = int(np.argmax(sims))
+    if sims[idx] < 0.6:
+        raise HTTPException(status_code=404, detail="No match")
+    return {"user_id": str(user_ids[idx]), "score": float(sims[idx])}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Face Attendance</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; }
+        video { width: 100%; max-width: 400px; }
+    </style>
+</head>
+<body>
+    <h1>Face Attendance</h1>
+    <video id="video" autoplay playsinline></video>
+    <button id="capture">Check In</button>
+
+    <script src="https://cdn.jsdelivr.net/npm/face-api.js"></script>
+    <script>
+    const video = document.getElementById('video');
+    async function startCamera() {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        video.srcObject = stream;
+    }
+
+    async function getEmbedding() {
+        await faceapi.nets.ssdMobilenetv1.loadFromUri('/models');
+        await faceapi.nets.faceRecognitionNet.loadFromUri('/models');
+        const detections = await faceapi.detectSingleFace(video).withFaceLandmarks().withFaceDescriptor();
+        if (!detections) return null;
+        return Array.from(detections.descriptor);
+    }
+
+    document.getElementById('capture').onclick = async () => {
+        const embedding = await getEmbedding();
+        if (!embedding) {
+            alert('No face detected');
+            return;
+        }
+        const res = await fetch('/api/identify', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ vector: embedding })
+        });
+        if (res.ok) {
+            const data = await res.json();
+            alert('Welcome ' + data.user_id + ' score: ' + data.score.toFixed(2));
+        } else {
+            alert('Face not recognized');
+        }
+    };
+
+    startCamera();
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+numpy
+onnxruntime
+pydantic


### PR DESCRIPTION
## Summary
- implement FastAPI endpoint for face identification
- add simple HTML/JS front-end for webcam capture
- list dependencies in requirements.txt
- document running server and Vercel deploy instructions

## Testing
- `python -m py_compile api/identify.py`
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841340adfb88321b103b2f345aa527e